### PR TITLE
changed variable name to avoid name diplication

### DIFF
--- a/controllers/README.md
+++ b/controllers/README.md
@@ -30,7 +30,7 @@ up looking like this:
 
 ``` go
 func MyHandler(r *render.Render) http.Handler {
-  return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+  return http.HandlerFunc(func(rw http.ResponseWriter, rq *http.Request) {
     // now we can access r
   })
 }


### PR DESCRIPTION
Changed argument name to avoid losing the reference to another object with
the same name, available from the parent scope.
